### PR TITLE
Add HtmlToText method

### DIFF
--- a/slc/mail2news/browser/mailhandler.py
+++ b/slc/mail2news/browser/mailhandler.py
@@ -81,6 +81,12 @@ class MailHandler(BrowserView):
         )
         return header_decoded
 
+    def HtmlToText(self, text):
+        pt = api.portal.get_tool("portal_transforms")
+        plain = pt.convertToData("text/plain", text)
+        data = " ".join(plain.strip().split())
+        return data
+
     def addMail(self, mailstring):
         """ Store mail as news item
             Returns created item


### PR DESCRIPTION
Fixes error when trying to call with html mail, but may not yield satisfying results because it does not reliably strip away any CSS, signatures etc.

Ref syslabcom/scrum#2428